### PR TITLE
specify requirements without direct reference

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     install_requires = [
-        'fasm @ git+https://github.com/symbiflow/fasm#egg=fasm',
-        'fasm-utils @ git+https://github.com/QuickLogic-Corp/quicklogic-fasm-utils#egg=fasm-utils'
+        'fasm',
+        'fasm-utils @ git+https://github.com/QuickLogic-Corp/quicklogic-fasm-utils'
     ],
 )


### PR DESCRIPTION
This PR is fixing issues while using this package in [symbiflow-arch-defs](https://github.com/SymbiFlow/symbiflow-arch-defs/pull/2167)
There is an existing package in python repository for [fasm](https://pypi.org/project/fasm/) so it is not needed to fetch it from github.
In case of `fasm-utils`, we provide the package name before the `@` .

Signed-off-by: Paweł Czarnecki <pczarnecki@antmicro.com>