### PR TITLE
Extend support for PP3 bitstream generation

### DIFF
--- a/quicklogic_fasm/qlassembler/QLAssembler.py
+++ b/quicklogic_fasm/qlassembler/QLAssembler.py
@@ -86,7 +86,6 @@ class QLAssembler(fasm_assembler.FasmAssembler):
                     bitidx = 0
                     if banknum in (0, 8, 16, 24):
                         if bitnum in (0, 1):
-                            val = 0
                             continue
                         else:
                             bitidx = self.BANKSTARTBITIDX[banknum] + bitnum - 2
@@ -96,9 +95,6 @@ class QLAssembler(fasm_assembler.FasmAssembler):
                         val = get_value_for_coord(wlidx, self.MAXWL // 2, bitidx)
                     else:
                         val = get_value_for_coord(wlidx, 0, bitidx)
-
-                    if val == -1:
-                        val = 0
 
                     if val == 1:
                         currval = currval | (1 << banknum)

--- a/quicklogic_fasm/qlassembler/eos_s3/ql732b.py
+++ b/quicklogic_fasm/qlassembler/eos_s3/ql732b.py
@@ -3,6 +3,11 @@ from quicklogic_fasm.qlassembler import QLAssembler as qlasm
 
 class QL732BAssembler(qlasm.QLAssembler):
 
+    bank_start_idx = [0, 43, 88, 133, 178, 223, 268, 313,
+                      673, 628, 583, 538, 493, 448, 403, 358,
+                      0, 43, 88, 133, 178, 223, 268, 313,
+                      673, 628, 583, 538, 493, 448, 403, 358]
+
     def __init__(self, db):
         '''Class for generating bitstream for QuickLogic's QL732B FPGA.
 
@@ -10,5 +15,27 @@ class QL732BAssembler(qlasm.QLAssembler):
         with ql732b specific parameters.
         :param MAXBL: the maximum value for bit line
         :param MAXWL: the maximum value for word line
+        :param NUMOFBANKS: the number of config bit banks, source: QLAL4SB3.xml
+        :param BANKSTARTBITIDX: contains the bit offset for a given bank, source: QLAL4SB3.xml
         '''
-        super().__init__(db, 716, 844)
+        self.BANKSTARTBITIDX = self.bank_start_idx
+        self.MAXBL = 716
+        self.MAXWL = 844
+        self.NUMOFBANKS = 32
+        super().__init__(db)
+
+    def calc_bitidx(self, banknum, bitnum):
+        '''calculates the bit index (Y coordinate) and .
+
+        Parameters
+        ----------
+        banknum: Bank number.
+        bitnum: bit number in bank.
+        '''
+        if banknum in (0, 8, 16, 24):
+            if bitnum in (0, 1):
+                return -1
+            else:
+                return self.BANKSTARTBITIDX[banknum] + bitnum - 2
+        else:
+            return self.BANKSTARTBITIDX[banknum] + bitnum

--- a/quicklogic_fasm/qlassembler/pp3/ql725a.py
+++ b/quicklogic_fasm/qlassembler/pp3/ql725a.py
@@ -8,7 +8,7 @@ class QL725AAssembler(qlasm.QLAssembler):
     bank_start_idx = [0, 222, 664, 443, 0, 222, 664, 443]
 
     def __init__(self, db, spi_master=True, osc_freq=False, ram_en=0, cfg_write_chcksum_post=True,
-                cfg_read_chcksum_post=False, cfg_done_out_mask=False, add_header=True):
+                cfg_read_chcksum_post=False, cfg_done_out_mask=False, add_header=True, add_checksum=True):
         '''Class for generating bitstream for QuickLogic's QL725A FPGA.
         :param spi_master: True - assembler mode for SPI Master bitstream generation, False - SPI Slave
         :param osc_freq: internal oscillator frequency select True - high (20MHz), False - low (5MHz),
@@ -34,7 +34,8 @@ class QL725AAssembler(qlasm.QLAssembler):
                     PASS: [2’b10, preamble[5:0]] - configuration completed, checksum is correct.
                     FAIL: [2’b11, preamble[5:0]] - configuration completed, checksum is incorrect.
         :param add_header: include PP3 specific header to the beginning of the final bitstream file
-
+        :param add_checksum: include checksum for the configuration and RAM initialization payload
+                             at the end of the final bitstream file
 
         Class inherits from QLAssembler class, and wraps it
         with ql725a specific parameters.
@@ -50,6 +51,7 @@ class QL725AAssembler(qlasm.QLAssembler):
         self.cfg_write_chcksum_post = int(cfg_write_chcksum_post)
         self.cfg_done_out_mask = int(cfg_done_out_mask)
         self.add_header = add_header
+        self.add_checksum = add_checksum
 
         self.BANKSTARTBITIDX = self.bank_start_idx
         self.MAXBL = 886
@@ -99,6 +101,29 @@ class QL725AAssembler(qlasm.QLAssembler):
 
         return header;
 
+    def produce_bitstream_checksum(self, bitstream):
+        checksum = 0
+
+        # FIXME: include RAM data in checksum calculation based on ram_en
+        if (self.spi_master):
+            checksum = self.fletcher32(bitstream[6:])
+        else:
+            checksum = self.fletcher32(bitstream[5:])
+
+        checksum_bytes = checksum.to_bytes(4, "little")
+
+        return checksum_bytes
+
+    def fletcher32(self, data):
+        c0 = 0
+        c1 = 0
+
+        for byte in data:
+            c0 = (c0 + byte) % 65535
+            c1 = (c1 + c0) % 65535
+
+        return (c1 << 16) | c0
+
     def produce_bitstream(self, outfilepath: str, verbose=False):
         def get_value_for_coord(wlidx, wlshift, bitidx):
             coord = (wlidx + wlshift, bitidx)
@@ -130,6 +155,9 @@ class QL725AAssembler(qlasm.QLAssembler):
                 if verbose:
                     print('{}_{}:  {:02X}'.format(wlidx, bitnum, currval))
                 bitstream.append(currval)
+
+        if (self.add_checksum):
+            bitstream += self.produce_bitstream_checksum(bitstream)
 
         if verbose:
             print('Size of bitstream:  {}B'.format(len(bitstream) * 4))

--- a/quicklogic_fasm/qlassembler/pp3/ql725a.py
+++ b/quicklogic_fasm/qlassembler/pp3/ql725a.py
@@ -1,14 +1,176 @@
 #!/usr/bin/env python3
 from quicklogic_fasm.qlassembler import QLAssembler as qlasm
+from fasm import FasmLine
+import os
 
 class QL725AAssembler(qlasm.QLAssembler):
 
-    def __init__(self, db):
+    bank_start_idx = [0, 222, 664, 443, 0, 222, 664, 443]
+
+    def __init__(self, db, spi_master=True, osc_freq=False, ram_en=0, cfg_write_chcksum_post=True,
+                cfg_read_chcksum_post=False, cfg_done_out_mask=False, add_header=True):
         '''Class for generating bitstream for QuickLogic's QL725A FPGA.
+        :param spi_master: True - assembler mode for SPI Master bitstream generation, False - SPI Slave
+        :param osc_freq: internal oscillator frequency select True - high (20MHz), False - low (5MHz),
+        :param ram_en: one-hot coded RAM access enable - when bit[i] is set to 1, it means ith RAM will be written,
+        :param cfg_write_chcksum_post: UNUSED when spi_master==False
+                True - Configuration Write Checksum Post: PolarProIII reads the data back and
+                    performs the checksum after the data is written to Cfg Bit Cells and RAM.
+                    This mode can verify not only the SPI bus integrity but also the data
+                    integrity inside the Cfg Bit Cells and RAM. It will take a longer time
+                    to configure the PolarProIII.
+                False - Configuration Write Checksum Pre: PolarProIII performs the checksum before
+                    the data is written to the Cfg Bit Cells and RAM. It can only verifies the
+                    the integrity of SPI bus. It takes a shorter time to configure the PolarProIII.
+,
+        :param cfg_read_chcksum_post: Configuration Read Checksum Post - This command is for SPI Master
+                                      to check the Status of PolarProIII. UNUSED when spi_master==True
+        :param cfg_done_out_mask: cfg_done output mask, UNUSED when spi_master==True
+                False - cfg_done output is masked, cfg_done is always 0
+                True - cfg_done out is not masked, cfg_done reflects the status of PolarProIII
+                PolarProIII defines 4 statuses:
+                    IDLE: [2’b00, preamble[5:0]] - no command received after power up or SPI RESET.
+                    BUSY: [2’b01, preamble[5:0]] - during the configuration write.
+                    PASS: [2’b10, preamble[5:0]] - configuration completed, checksum is correct.
+                    FAIL: [2’b11, preamble[5:0]] - configuration completed, checksum is incorrect.
+        :param add_header: include PP3 specific header to the beginning of the final bitstream file
+
 
         Class inherits from QLAssembler class, and wraps it
         with ql725a specific parameters.
         :param MAXBL: the maximum value for bit line
         :param MAXWL: the maximum value for word line
+        :param NUMOFBANKS: the number of config bit banks, source: QL3P1K.xml
+        :param BANKSTARTBITIDX: contains the bit offset for a given bank, source: QL3P1K.xml
         '''
-        super().__init__(db, 884, 886)
+        self.spi_master = int(spi_master)
+        self.osc_freq = int(osc_freq)
+        self.ram_en = ram_en
+        self.cfg_read_chcksum_post = int(cfg_read_chcksum_post)
+        self.cfg_write_chcksum_post = int(cfg_write_chcksum_post)
+        self.cfg_done_out_mask = int(cfg_done_out_mask)
+        self.add_header = add_header
+
+        self.BANKSTARTBITIDX = self.bank_start_idx
+        self.MAXBL = 886
+        self.MAXWL = 888
+        self.NUMOFBANKS = 8
+        super().__init__(db)
+
+
+    def calc_bitidx(self, banknum, bitnum):
+        '''calculates the bit index (Y coordinate) and .
+
+        Parameters
+        ----------
+        banknum: Bank number.
+        bitnum: bit number in bank.
+        '''
+        if banknum in (1, 3, 4, 6):     # Banks with max bit line == 221
+            if bitnum == 0:
+                return -1
+            else:
+                return self.BANKSTARTBITIDX[banknum] + bitnum - 1
+        else:
+            return self.BANKSTARTBITIDX[banknum] + bitnum
+
+    def produce_bitstream_header(self):
+        header = []
+
+        if (self.spi_master):
+            command = ((self.cfg_write_chcksum_post << 1) | self.osc_freq) & 0b11
+            command = ((~command << 2) | command) & 0b1111
+            command = ((~command << 4) | command) & 0b11111111
+        else:
+            if (self.cfg_read_chcksum_post):
+                command = (1 << 2) | (1 << 1) | self.osc_freq
+            else:
+                command = (self.cfg_write_chcksum_post << 1) | self.osc_freq
+            command = (self.cfg_done_out_mask << 7) | command
+
+        if (self.spi_master):
+            header.append(0x59)  # fixed PP3-specific preamble
+        header.append(command)      # internal oscillator frequency and checksum config
+        header.append(self.ram_en)       # parameter 0 - one hot RAM enable config
+
+        # parameters 1-3 - reserved
+        for i in range(0, 3):
+            header.append(0)
+
+        return header;
+
+    def produce_bitstream(self, outfilepath: str, verbose=False):
+        def get_value_for_coord(wlidx, wlshift, bitidx):
+            coord = (wlidx + wlshift, bitidx)
+            if coord not in self.configbits:
+                return -1
+            else:
+                return self.configbits[coord]
+
+        bitstream = []
+
+        if (self.add_header):
+            bitstream = self.produce_bitstream_header()
+
+        for wlidx in range(self.MAXWL // 2 - 1, -1, -1):
+            for bitnum in range(0, self.BANKNUMBITS):
+                currval = 0
+                for banknum in range(self.NUMOFBANKS - 1, -1, -1):
+                    val = 1
+                    bitidx = self.calc_bitidx(banknum, bitnum)
+                    if (bitidx == -1):
+                        continue
+                    if banknum >= self.NUMOFBANKS // 2:
+                        val = get_value_for_coord(wlidx, self.MAXWL // 2, bitidx)
+                    else:
+                        val = get_value_for_coord(wlidx, 0, bitidx)
+
+                    if val == 1:
+                        currval = currval | (1 << banknum)
+                if verbose:
+                    print('{}_{}:  {:02X}'.format(wlidx, bitnum, currval))
+                bitstream.append(currval)
+
+        if verbose:
+            print('Size of bitstream:  {}B'.format(len(bitstream) * 4))
+
+        with open(outfilepath, 'w+b') as output:
+            for batch in bitstream:
+                output.write(batch.to_bytes(4, 'little'))
+
+        mem_file = os.path.join(os.path.dirname(outfilepath), "ram.mem")
+        with open(mem_file, 'w') as output:
+            for x,y in self.memdict.items():
+                output.write("0x{:08x}:0x{:08x}\n".format(x,y))
+
+    def populate_meminit(self, fasmline: FasmLine):
+        raise NotImplementedError()
+
+    def read_bitstream(self, bitfilepath):
+        '''Reads bitstream from file.
+
+        Parameters
+        ----------
+        bitfilepath: str
+            A path to the binary file with bitstream
+        '''
+        raise NotImplementedError()
+
+    def disassemble(self, outfilepath: str = None, verbose=False):
+        '''Converts bitstream to FASM lines.
+
+        This method converts the bits obtained with `read_bitstream` method
+        to FASM lines and returns them. It also can save FASM lines to a file.
+
+        Parameters
+        ----------
+        outfilepath: str
+            An optional path to the output file containing FASM lines
+        verbose: bool
+            If true, the verbose messages will be printed in stdout
+
+        Returns
+        -------
+        list: A list of FASM lines
+        '''
+        raise NotImplementedError()

--- a/quicklogic_fasm/qlfasm.py
+++ b/quicklogic_fasm/qlfasm.py
@@ -116,7 +116,14 @@ def main():
 
     assembler = None
     if (args.dev_type == "ql-pp3"):
-        assembler = QL725AAssembler(db)
+        assembler = QL725AAssembler(db,
+                                    spi_master=True,
+                                    osc_freq=True,
+                                    ram_en=False,
+                                    cfg_write_chcksum_post=True,
+                                    cfg_read_chcksum_post=False,
+                                    cfg_done_out_mask=False,
+                                    add_header=True)
     elif (args.dev_type == "ql-eos-s3"):
         assembler = QL732BAssembler(db)
     elif (args.dev_type == "ql-pp3e"):

--- a/quicklogic_fasm/qlfasm.py
+++ b/quicklogic_fasm/qlfasm.py
@@ -123,7 +123,8 @@ def main():
                                     cfg_write_chcksum_post=True,
                                     cfg_read_chcksum_post=False,
                                     cfg_done_out_mask=False,
-                                    add_header=True)
+                                    add_header=True,
+                                    add_checksum=True)
     elif (args.dev_type == "ql-eos-s3"):
         assembler = QL732BAssembler(db)
     elif (args.dev_type == "ql-pp3e"):


### PR DESCRIPTION
The purpose of this PR is to introduce fixes for PP3 bitstream generation.
It applies part of the PP3 bitstream file format specification, namely:
* generating correct size of the configuration part of the bitstream
* generating basic checksum - at this moment it only calculates the checksum for the config bits part. This is to be extended by including RAM INIT part (when it is used) in next PR 
*  choosing SPI mode, oscillator frequency, when the checksum is verified, enabling the status output pin

For now, a hardcoded set of bitstream parameters (SPI mode, etc.) is introduced. However it is possible do generate bitstream with different parameters with instantiating different `QL725AAssembler` object.