### PR TITLE
pp3: generate 3 bitstream configurations simultaneously

### DIFF
--- a/quicklogic_fasm/qlfasm.py
+++ b/quicklogic_fasm/qlfasm.py
@@ -174,7 +174,22 @@ def main():
                 assembler.read_bitstream(default_bitstream)
 
         assembler.parse_fasm_filename(str(args.infile))
-        assembler.produce_bitstream(str(args.outfile), verbose=args.verbose)
+
+        if (args.dev_type == "ql-pp3"):
+            # Producing 3 bitstream configurations:
+            # 1. SPI master mode enabled (original filename)
+            # 2. SPI slave mode enabled (filename with _spi_slave)
+            # 3. No header and checksum (filename with _no_header_checksum)
+            assembler.produce_bitstream(str(args.outfile), verbose=args.verbose)
+
+            assembler.set_spi_master(False)
+            assembler.produce_bitstream(str(args.outfile), verbose=args.verbose)
+
+            assembler.set_header(False)
+            assembler.set_checksum(False)
+            assembler.produce_bitstream(str(args.outfile), verbose=args.verbose)
+        else:
+            assembler.produce_bitstream(str(args.outfile), verbose=args.verbose)
     else:
         assembler.read_bitstream(str(args.infile))
         assembler.disassemble(str(args.outfile), verbose=args.verbose)


### PR DESCRIPTION
This PR enables generation of 3 different bitstream files:
* enabled SPI master mode - file name is the original `outfilepath` 
* enabled SPI slave mode - file name has the `outfilepath` and  "_spi_slave" substring
* No header and checksum - file name has the `outfilepath` and "_no_header_checksum" substring

Bitstream file with the original filename passed to the script is the 'default' one that is used
in symbiflow in reverse targets `*_bit_v` that generate verilog out of given bitstream.
This file should have the same format as the bitstreams that are loaded to the HW.
That is the reason why the bitstream for the SPI mode has no "_spi_slave" substring in its file name

Signed-off-by: Pawel Czarnecki <pczarnecki@antmicro.com>