### PR TITLE
PP3: add support for RAM INIT configuration bits to the bitstream generation

### DIFF
--- a/quicklogic_fasm/qlassembler/QLAssembler.py
+++ b/quicklogic_fasm/qlassembler/QLAssembler.py
@@ -31,9 +31,9 @@ class QLAssembler(fasm_assembler.FasmAssembler):
         featurevalue = fasmline.set_feature.value
         baseaddress = int (self.membaseaddress[fasmline.set_feature.feature[:-13]], 16)
         for i in range(fasmline.set_feature.start //18, (fasmline.set_feature.end + 1) //18):
-           value = featurevalue & 262143
-           featurevalue = featurevalue >> 18
-           self.memdict[baseaddress+i*4] = value;
+            value = featurevalue & 262143
+            featurevalue = featurevalue >> 18
+            self.memdict[baseaddress+i*4] = value;
     
 
     def enable_feature(self, fasmline: FasmLine):

--- a/quicklogic_fasm/qlassembler/pp3/ql725a.py
+++ b/quicklogic_fasm/qlassembler/pp3/ql725a.py
@@ -258,7 +258,7 @@ class QL725AAssembler(qlasm.QLAssembler):
 
         # Check size, throw an error if too short
         # FIXME: Handle presence/absence of RAM init bits
-        num_cfg_bits = self.MAXWL * self.MAXBL
+        num_cfg_bits = self.BANKNUMBITS * self.NUMOFBANKS * self.MAXWL // 2
         num_cfg_bytes = num_cfg_bits // 8
         if len(bitstream) < num_cfg_bytes:
             raise RuntimeError("Bitstream too short ({} vs {})".format(

--- a/quicklogic_fasm/qlfasm.py
+++ b/quicklogic_fasm/qlfasm.py
@@ -133,7 +133,6 @@ def main():
         assembler = QL725AAssembler(db,
                                     spi_master=True,
                                     osc_freq=True,
-                                    ram_en=False,
                                     cfg_write_chcksum_post=True,
                                     cfg_read_chcksum_post=False,
                                     cfg_done_out_mask=False,


### PR DESCRIPTION
This PR adds the support for writing the ram initialization bits to the bitstream. There is a working logic for writing the RAM initialization bits to the bitstream. That part of the bitstream is also taken into account when it comes to checksum calculation and verifying against expected bitstream length while we are reading the bitstream.

There is also a conversion from raw RAM init data that was read from the bitstream to FASM lines in format: `XxYy.RAM.RAM.INIT[<SIZE>:0]=<SIZE>'b<INITBITS>`.

I was not able to find information about the ordering of particular blocks/banks of the RAM in documentation or provided code example. I based my implementation on the techfile for now.
The documentation refers to RAM banks with names `Bank0`, `Bank1`, etc. but there is no direct mapping of those names to ones in the [techfile](https://github.com/QuickLogic-Corp/PolarPro3/blob/master/Device%20Architecture%20Files/QL3P1K.xml#L254). I assumed that Bank0 is the first one in techfile and so on.

For PP3 we are not writing the `ram.mem` file so I simplified the base addresses because those are only used as keys for the memory contents dictionary.

On the symbiflow-arch-defs side some changes are required and those will be introduced with PR: https://github.com/QuickLogic-Corp/symbiflow-arch-defs/pull/678