### PR TITLE
pp3: change default assembler settings

### DIFF
--- a/quicklogic_fasm/qlassembler/pp3/ql725a.py
+++ b/quicklogic_fasm/qlassembler/pp3/ql725a.py
@@ -19,7 +19,7 @@ class QL725AAssembler(qlasm.QLAssembler):
     RAM_PADDING = TOTAL_BITS_PER_RAM_CELL - INIT_BITS_PER_RAM_CELL
     BYTES_PER_RAM_BLOCK = CELLS_PER_RAM_BLOCK * TOTAL_BITS_PER_RAM_CELL // 8
 
-    def __init__(self, db, spi_master=True, osc_freq=False, cfg_write_chcksum_post=True,
+    def __init__(self, db, spi_master=True, osc_freq=False, cfg_write_chcksum_post=False,
                 cfg_read_chcksum_post=False, cfg_done_out_mask=False, add_header=True, add_checksum=True,
                 verify_checksum=True):
         '''Class for generating bitstream for QuickLogic's QL725A FPGA.

--- a/quicklogic_fasm/qlfasm.py
+++ b/quicklogic_fasm/qlfasm.py
@@ -132,8 +132,8 @@ def main():
     if (args.dev_type == "ql-pp3"):
         assembler = QL725AAssembler(db,
                                     spi_master=True,
-                                    osc_freq=True,
-                                    cfg_write_chcksum_post=True,
+                                    osc_freq=False,
+                                    cfg_write_chcksum_post=False,
                                     cfg_read_chcksum_post=False,
                                     cfg_done_out_mask=False,
                                     add_header=True,


### PR DESCRIPTION
This PR addresses https://github.com/QuickLogic-Corp/symbiflow-arch-defs/issues/659 and problems described in https://github.com/QuickLogic-Corp/symbiflow-arch-defs/issues/640#issuecomment-969838757.
It sets default internal oscillator frequency to 5MHz and enables `configuration_write_checksum_pre` option for the bitstream so that bitstream with SPI slave mode should be the same as working example.
This PR meant to be introduced together with the https://github.com/QuickLogic-Corp/symbiflow-arch-defs/pull/683

Signed-off-by: Paweł Czarnecki <pczarnecki@antmicro.com>