### PR TITLE
add positional argument with iomux configuration to bitstream_to_* scripts

### DIFF
--- a/quicklogic_fasm/bitstream_to_binary.py
+++ b/quicklogic_fasm/bitstream_to_binary.py
@@ -42,6 +42,13 @@ if __name__ == '__main__':
         help="The output file (binary)",
     )
 
+    parser.add_argument(
+        "iomux",
+        nargs='?',
+        type=Path,
+        help="iomux configuration (binary)",
+    )
+
     args = parser.parse_args()
 
     # create bytearray for the fpga binary content
@@ -153,6 +160,8 @@ if __name__ == '__main__':
     # if bitstream file == NAME.bit, then the iomux binary will be generated as:
     # NAME_iomux.bin, use this to locate the iomux binary
     iomuxbin_file_path = Path(args.infile.parent).joinpath(args.infile.stem + "_iomux.bin")
+    if (args.iomux):
+        iomuxbin_file_path = args.iomux
     iomux_size = Path(iomuxbin_file_path).stat().st_size
     with open(iomuxbin_file_path, 'rb') as iomuxbin:
         fpga_bin_content_byte_array.extend(iomuxbin.read())

--- a/quicklogic_fasm/bitstream_to_header.py
+++ b/quicklogic_fasm/bitstream_to_header.py
@@ -25,6 +25,13 @@ if __name__ == '__main__':
         help="The output file (Header script)",
     )
 
+    parser.add_argument(
+        "iomux",
+        nargs='?',
+        type=Path,
+        help="iomux configuration (binary)",
+    )
+
     args = parser.parse_args()
 
     ############# BITSTREAM ARRAY #################
@@ -105,6 +112,8 @@ if __name__ == '__main__':
     # if bitstream file == NAME.bit, then the iomux binary will be generated as:
     # NAME_iomux.bin, use this to locate the iomux binary
     iomuxbin_file = Path(args.infile.parent).joinpath(args.infile.stem + "_iomux.bin")
+    if (args.iomux):
+        iomuxbin_file = args.iomux
 
     with open(iomuxbin_file, 'rb') as iomuxbin:
         counter = 1

--- a/quicklogic_fasm/bitstream_to_jlink.py
+++ b/quicklogic_fasm/bitstream_to_jlink.py
@@ -66,6 +66,13 @@ if __name__ == '__main__':
         help="The output file (JLink script)",
     )
 
+    parser.add_argument(
+        "iomux",
+        nargs='?',
+        type=Path,
+        help="iomux configuration (JLink script)",
+    )
+
     args = parser.parse_args()
 
 
@@ -117,6 +124,8 @@ if __name__ == '__main__':
     # if bitstream file == NAME.bit, then the iomux jlink script will be generated as:
     # NAME_iomux.jlink, use this to locate the iomux binary
     iomuxjlink_file = Path(args.infile.parent).joinpath(args.infile.stem + "_iomux.jlink")
+    if (args.iomux):
+        iomuxjlink_file = args.iomux
 
     with open(iomuxjlink_file, 'r') as iomuxjlink:
         iomux_lines = iomuxjlink.readlines()

--- a/quicklogic_fasm/bitstream_to_openocd.py
+++ b/quicklogic_fasm/bitstream_to_openocd.py
@@ -103,6 +103,13 @@ if __name__ == '__main__':
     )
 
     parser.add_argument(
+        "iomux",
+        nargs='?',
+        type=Path,
+        help="iomux configuration (OpenOCD script)",
+    )
+
+    parser.add_argument(
         "--osc-freq",
         type=int,
         default=60000000,
@@ -173,6 +180,8 @@ if __name__ == '__main__':
     # if bitstream file == NAME.bit, then the iomux openocd script will be generated as:
     # NAME_iomux.openocd, use this to locate the iomux binary
     iomuxopenocd_file = Path(args.infile.parent).joinpath(args.infile.stem + "_iomux.openocd")
+    if (args.iomux):
+        iomuxopenocd_file = args.iomux
 
     with open(iomuxopenocd_file, 'r') as iomuxopenocd:
         iomux_lines = iomuxopenocd.readlines()


### PR DESCRIPTION
This PR slightly modifies `bitstream_to_*` bitstream conversion scripts. It adds optional input arguments for passing iomux configuration paths. If this option is not used, then script acts as previously (inferring path to iomux configuration from bitstream path). This change is required to use those scripts in new F4PGA build flow (see https://github.com/chipsalliance/f4pga/pull/577, `f4pga build` requires explicit input arguments to run external scripts in F4PGA flow).

Signed-off-by: Pawel Czarnecki <pczarnecki@antmicro.com>